### PR TITLE
Legacy Mode Notifications

### DIFF
--- a/postflight/postflight
+++ b/postflight/postflight
@@ -210,7 +210,7 @@ def process_pending_apple_updates(pending_apple_updates):
         # If we have more pending updates than last run or we have pending updates &
         # are using the dataJAR Notifier, post notification
         if (pending_apple_updates > last_apple_pending_count or
-                pending_apple_updates > 0 and DATAJAR_NOTIFIER):
+                pending_apple_updates > 0 and DATAJAR_NOTIFIER and not DATAJAR_NOTIFIER_LEGACY_MODE):
             send_pending_apple_update_notification(False)
 
     # Update pending_count in /Library/Preferences/uk.co.dataJAR.jamJAR.plist

--- a/postflight/postflight
+++ b/postflight/postflight
@@ -250,7 +250,7 @@ def process_pending(pending_items):
             os.unlink('/private/tmp/com.googlecode.munki.installatlogout')
     # If we have pending updates & are using the dataJAR Notifier and we're logged in,
     # then post a notification
-    elif (pending_items > 0 and DATAJAR_NOTIFIER) and username:
+    elif (pending_items > 0 and DATAJAR_NOTIFIER and not DATAJAR_NOTIFIER_LEGACY_MODE) and username:
         send_pending_notification(False)
         if not os.path.exists('/private/tmp/com.googlecode.munki.installatlogout'):
             open('/private/tmp/com.googlecode.munki.installatlogout', 'w').close()
@@ -454,6 +454,10 @@ if __name__ == "__main__":
     DATAJAR_NOTIFIER = CFPreferencesCopyAppValue('datajar_notifier', 'uk.co.dataJAR.jamJAR')
     if DATAJAR_NOTIFIER is None:
         DATAJAR_NOTIFIER = False
+
+    DATAJAR_NOTIFIER_LEGACY_MODE = CFPreferencesCopyAppValue('datajar_notifier_legacy_mode', 'uk.co.dataJAR.jamJAR')
+    if DATAJAR_NOTIFIER_LEGACY_MODE is None:
+        DATAJAR_NOTIFIER_LEGACY_MODE = False
 
     DATAJAR_NOTIFIER_LOGOUT_BUTTON = CFPreferencesCopyAppValue('datajar_notifier_logout_button', \
                                                                          'uk.co.dataJAR.jamJAR')


### PR DESCRIPTION
I think this would be a valuable addition to emulate the jamJAR v1 notifications, but still allow for usage of the Notifier app. Legacy Mode would default to being off. With it on, notifications will only be sent if there are more pending updates than the previous run. 